### PR TITLE
Added decorator @SerializeUndecorated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,52 @@ console.log(deserializedClient);
 */
 ```
 
+By default all undecorated properties (which don't have a decorator `@JsonProperty()`) ignore during the serialization into json-object.
+Decorator `@SerializeUndecorated` can corrects this case and cancel the ignoring such properties.
+
+```typescript
+
+import { SerializeUndecorated, JsonProperty, JsTsMapper } from "js-ts-mapper";
+
+@SerializeUndecorated()
+export class Employeer {
+    constructor(o) {
+        Object.assign(this, o);
+    }
+
+    @JsonProperty('Id')
+    id: number;
+
+    @JsonProperty('FirstName')
+    firstName: string;
+
+    @JsonProperty('LastName')
+    lastName: string;
+
+    @JsonProperty('MiddleName')
+    middleName: string;
+
+    selected: boolean = true;
+}
+
+let test_entity = new Employeer({
+    id: 256,
+    firstName: 'Test',
+    lastName: 'Test',
+    middleName: 'Test',
+    selected: true
+});
+
+let out = mapper.serialize(test_entity);    
+/*
+    returns
+    {
+        selected: true,
+        Id: 256,
+        FirstName: 'Test',
+        LastName: 'Test',
+        MiddleName: 'Test'
+    }
+*/
+
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
 // Объявляем уникальные ключи, по которым будем идентифицировать наши метаданные
 export const ServerNameMetadataKey = 'serverName';
 export const AvailableFieldsMetadataKey = 'availableFields';
+export const IgnoreUndecoratedPropertyKey = 'ignoreUndecoratedProperty';

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { ServerNameMetadataKey, AvailableFieldsMetadataKey } from './config';
+import { ServerNameMetadataKey, AvailableFieldsMetadataKey, IgnoreUndecoratedPropertyKey } from './config';
 import { JsTsCustomConvert, BaseJsTsCustomConvert } from './interface';
 import { FieldProperty } from './field-property';
 
@@ -56,5 +56,11 @@ export function JsonProperty(name?: string, customConverter?:  { new (): BaseJsT
         if (field) {
             availableFields.push(field);
         }
+    };
+}
+
+export function SerializeUndecorated(enabled: boolean = true) {
+    return (target: Object) => {     
+        Reflect.defineMetadata(IgnoreUndecoratedPropertyKey, !enabled, target);
     };
 }

--- a/tests/JsTsMapper/scenarios/serialize/anonimus-object.it.ts
+++ b/tests/JsTsMapper/scenarios/serialize/anonimus-object.it.ts
@@ -1,0 +1,25 @@
+import { JsTsMapper } from 'ts-mapper';
+import { UtilTestTools } from '../../../services/utils.srv';
+
+export function run(mapper: JsTsMapper) {
+  it('serialize component with inner component', () => {
+    let test_entity = {
+      id: 256,
+      firstName: 'Test',
+      lastName: 'Test',
+      middleName: 'Test',
+      selected: true
+    };
+
+    let result: any = {
+        id: 256,
+        firstName: 'Test',
+        lastName: 'Test',
+        middleName: 'Test',
+        selected: true
+      };
+
+    let out = mapper.serialize(test_entity);
+    UtilTestTools.expectEqual(out, result);
+  });
+}

--- a/tests/JsTsMapper/scenarios/serialize/ignore-undecorated-property.it.ts
+++ b/tests/JsTsMapper/scenarios/serialize/ignore-undecorated-property.it.ts
@@ -1,0 +1,42 @@
+import { JsTsMapper } from 'ts-mapper';
+import { Employeer, Employeer2 } from '../../../models/employeer';
+import { UtilTestTools } from '../../../services/utils.srv';
+
+export function run(mapper: JsTsMapper) {
+  it('serialize undecorated property', () => {
+    let test_entity = new Employeer({
+      id: 256,
+      firstName: 'Test',
+      lastName: 'Test',
+      middleName: 'Test',
+      selected: true
+    });
+
+    let result: any = {
+      selected: true,
+      Id: 256,
+      FirstName: 'Test',
+      LastName: 'Test',
+      MiddleName: 'Test'
+    };
+
+    let out = mapper.serialize(test_entity);
+    UtilTestTools.expectEqual(out, result);
+
+    test_entity = new Employeer2({
+      id: 256,
+      firstName: 'Test',
+      lastName: 'Test',
+      middleName: 'Test',
+      selected: true
+    });
+    result = {
+      Id: 256,
+      FirstName: 'Test',
+      LastName: 'Test',
+      MiddleName: 'Test'
+    };
+    out = mapper.serialize(test_entity);
+    UtilTestTools.expectEqual(out, result);
+  });
+}

--- a/tests/models/employeer.ts
+++ b/tests/models/employeer.ts
@@ -1,0 +1,42 @@
+import { SerializeUndecorated, JsonProperty } from "../../src/decorators";
+
+@SerializeUndecorated()
+export class Employeer {
+    constructor(o) {
+        Object.assign(this, o);
+    }
+
+    @JsonProperty('Id')
+    id: number;
+
+    @JsonProperty('FirstName')
+    firstName: string;
+
+    @JsonProperty('LastName')
+    lastName: string;
+
+    @JsonProperty('MiddleName')
+    middleName: string;
+
+    selected: boolean = true;
+}
+
+export class Employeer2 {
+    constructor(o) {
+        Object.assign(this, o);
+    }
+    
+    @JsonProperty('Id')
+    id: number;
+
+    @JsonProperty('FirstName')
+    firstName: string;
+
+    @JsonProperty('LastName')
+    lastName: string;
+
+    @JsonProperty('MiddleName')
+    middleName: string;
+
+    selected: boolean = true;
+}


### PR DESCRIPTION
Правки:
1. При передаче методу `serialize` анонимного объекта, возвращается тот же объект.
2. При попытке сериализации экземпляров объявленных классов, cвойства без декоратора `@JsonProperty` по умолчанию игнорируются и не фигурируют в выходном объекте.
Положение призван поправить декоратор `@SerializeUndecorated` объявленный над классом. 
Если он вызван, то абсолютно все свойства попадают в результат сериализации, а затем корректируются декораторами `@JsonProperty`.

Сериализованный объект, как правило, уходит на сервер и его состав должен быть четко описан в классах. А всякие служебные свойства попавшие к объект (вроде selected, checked и т. д.) будут по умолчанию игнорироваться.